### PR TITLE
Update openssl and nginx and bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ nginx:
 	mkdir -p $@
 
 nginx/nginx: nginx pcre .nginx-patched .openssl-patched
-	cd src && ./configure --with-cc-opt=-static --with-ld-opt=-static \
+	cd src && ./configure --with-cc-opt=-Bstatic --with-ld-opt=-Bstatic \
 		--with-cpu-opt=generic --with-pcre=../pcre --with-mail \
 		--with-ipv6 --with-poll_module --with-select_module \
 		--with-select_module --with-poll_module --with-http_ssl_module \

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 #       binary without any dependencies on the host system's version of glibc.
 
 # URL of nginx source tarball
-NGINX_SOURCE=http://nginx.org/download/nginx-1.9.2.tar.gz
+NGINX_SOURCE=http://nginx.org/download/nginx-1.11.3.tar.gz
 # URL of OpenSSL source tarball
-OPENSSL_SOURCE=http://www.openssl.org/source/openssl-1.0.1p.tar.gz
+OPENSSL_SOURCE=http://www.openssl.org/source/openssl-1.0.2h.tar.gz
 # URL of PCRE source tarball
 PCRE_SOURCE=http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.39.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ nginx/nginx: nginx pcre .nginx-patched .openssl-patched
 		--with-cpu-opt=generic --with-pcre=../pcre --with-mail \
 		--with-ipv6 --with-poll_module --with-select_module \
 		--with-select_module --with-poll_module --with-http_ssl_module \
-		--with-http_spdy_module --with-http_realip_module \
+		--with-http_realip_module \
 		--with-http_addition_module --with-http_sub_module \
 		--with-http_dav_module --with-http_flv_module \
 		--with-http_mp4_module --with-http_gunzip_module \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NGINX_SOURCE=http://nginx.org/download/nginx-1.9.2.tar.gz
 # URL of OpenSSL source tarball
 OPENSSL_SOURCE=http://www.openssl.org/source/openssl-1.0.1p.tar.gz
 # URL of PCRE source tarball
-PCRE_SOURCE=http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.37.tar.gz
+PCRE_SOURCE=http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.39.tar.gz
 
 all: nginx/nginx
 


### PR DESCRIPTION
Update:

```
nginx-1.9.2.tar.gz > nginx-1.11.3.tar.gz
openssl-1.0.1p.tar.gz > openssl-1.0.2h.tar.gz
```

Bug fix by remove "--with-http_spdy_module"

```
./configure: error: invalid option "--with-http_spdy_module"
make: *** [nginx/nginx] Error 1
```
